### PR TITLE
docs: fix @plugin install paths in plugin READMEs

### DIFF
--- a/psmux-git-status/README.md
+++ b/psmux-git-status/README.md
@@ -30,7 +30,7 @@ The must-have plugin for developers. Shows branch name, dirty/clean status, stag
 ## Installation
 
 ```
-set -g @plugin 'psmux/psmux-plugins/psmux-git-status'
+set -g @plugin 'psmux-plugins/psmux-git-status'
 ```
 
 ## Usage

--- a/psmux-net-speed/README.md
+++ b/psmux-net-speed/README.md
@@ -13,7 +13,7 @@ Shows real-time upload and download speeds with Nerd Font icons.
 ## Installation
 
 ```
-set -g @plugin 'psmux/psmux-plugins/psmux-net-speed'
+set -g @plugin 'psmux-plugins/psmux-net-speed'
 ```
 
 ## Usage

--- a/psmux-theme-everforest/README.md
+++ b/psmux-theme-everforest/README.md
@@ -18,7 +18,7 @@ A warm green-toned theme designed for long coding sessions. Features powerline s
 ## Installation
 
 ```
-set -g @plugin 'psmux/psmux-plugins/psmux-theme-everforest'
+set -g @plugin 'psmux-plugins/psmux-theme-everforest'
 ```
 
 ## Options

--- a/psmux-theme-kanagawa/README.md
+++ b/psmux-theme-kanagawa/README.md
@@ -15,7 +15,7 @@ Brings the distinctive wave/dragon/lotus color palettes to psmux with powerline 
 ## Installation
 
 ```
-set -g @plugin 'psmux/psmux-plugins/psmux-theme-kanagawa'
+set -g @plugin 'psmux-plugins/psmux-theme-kanagawa'
 ```
 
 ## Options

--- a/psmux-theme-onedark/README.md
+++ b/psmux-theme-onedark/README.md
@@ -7,7 +7,7 @@ Clean, modern dark theme with vibrant accent colors. Features powerline segments
 ## Installation
 
 ```
-set -g @plugin 'psmux/psmux-plugins/psmux-theme-onedark'
+set -g @plugin 'psmux-plugins/psmux-theme-onedark'
 ```
 
 ## Options

--- a/psmux-theme-rosepine/README.md
+++ b/psmux-theme-rosepine/README.md
@@ -23,7 +23,7 @@ A [Rosé Pine](https://rosepinetheme.com) theme for psmux with powerline segment
 Add to your `~/.psmux.conf`:
 
 ```
-set -g @plugin 'psmux/psmux-plugins/psmux-theme-rosepine'
+set -g @plugin 'psmux-plugins/psmux-theme-rosepine'
 ```
 
 ## Options


### PR DESCRIPTION
## Summary

Corrects the `set -g @plugin` examples so the psmux package manager can resolve plugins when installing from `.psmux.conf` (e.g. **PREF + I**).

**Before:** `psmux/psmux-plugins/<plugin-name>`  
**After:** `psmux-plugins/<plugin-name>`

## Plugins updated

Themes from #7:

- `psmux-theme-kanagawa`
- `psmux-theme-onedark`
- `psmux-theme-rosepine`
- `psmux-theme-everforest`

Also updated `psmux-net-speed` and `psmux-git-status`, which used the same incorrect path.

Fixes #7

Made with [Cursor](https://cursor.com)