### PR TITLE
fix(resurrect): strip status flags from window names during save

### DIFF
--- a/psmux-resurrect/scripts/save.ps1
+++ b/psmux-resurrect/scripts/save.ps1
@@ -42,7 +42,7 @@ foreach ($line in ($sessions -split "`n")) {
         foreach ($wline in ($windows -split "`n")) {
             if ($wline -match '^(\d+):\s+(\S+)') {
                 $winIndex = $Matches[1]
-                $winName = $Matches[2]
+                $winName = $Matches[2] -replace '[*!~#-]+$', ''
                 $windowData = @{
                     index = [int]$winIndex
                     name = $winName


### PR DESCRIPTION
## Summary

- `list-windows` appends status flags (`*` for active, `!` for bell, etc.) to window names. The save script's regex `(\S+)` captured these flags as part of the name, so each save/restore cycle accumulated extra asterisks (e.g. `python` → `python*` → `python**` → `python***`).
- Strips trailing status flag characters from captured window names with `-replace '[*!~#-]+$', ''`.

Fixes #9

## Test plan

- [ ] Create a session with named windows
- [ ] Save with psmux-resurrect, inspect JSON — names should be clean (no trailing `*`)
- [ ] Restore, save again — no accumulation of `*` characters
- [ ] Verify active window detection still works (uses `#{window_active}` separately, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)