### PR TITLE
fix(resurrect): replay saved window_layout on restore

### DIFF
--- a/psmux-resurrect/scripts/restore.ps1
+++ b/psmux-resurrect/scripts/restore.ps1
@@ -69,6 +69,10 @@ foreach ($session in $env_data.sessions) {
             & $PSMUX split-window -t "${sessionName}:${firstWinIdx}" -c $pDir 2>&1 | Out-Null
             Start-Sleep -Milliseconds 500
         }
+        # Replay the saved layout so split orientations and sizes match the original.
+        if ($firstWindow.layout) {
+            & $PSMUX select-layout -t "${sessionName}:${firstWinIdx}" $firstWindow.layout 2>&1 | Out-Null
+        }
     }
 
     # Create remaining windows
@@ -96,6 +100,10 @@ foreach ($session in $env_data.sessions) {
                 $pDir = if ($win.panes[$p].directory) { $win.panes[$p].directory } else { $env:USERPROFILE }
                 & $PSMUX split-window -t "${sessionName}:${lastWinIdx}" -c $pDir 2>&1 | Out-Null
                 Start-Sleep -Milliseconds 300
+            }
+            # Replay the saved layout so split orientations and sizes match the original.
+            if ($win.layout) {
+                & $PSMUX select-layout -t "${sessionName}:${lastWinIdx}" $win.layout 2>&1 | Out-Null
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #11.

`save.ps1` already records `#{window_layout}` for every window, but `restore.ps1` never replays it — it just loops `split-window` with no direction flag, and psmux defaults that to a vertical-stack split. Result: all restored panes come back stacked (horizontal dividers) regardless of the original layout.

This change calls `select-layout` once per window after its panes are recreated, using the saved layout string. psmux core already parses tmux layout strings (`src/layout.rs: parse_tmux_layout_string`), so the fix is plugin-only.

## Changes

- `psmux-resurrect/scripts/restore.ps1`: after splitting panes for each window, run `psmux select-layout -t <target> <saved_layout>` when a layout string is present.

## Test plan

- [x] Create a session with mixed horizontal + vertical splits, save, kill server, restore — pane geometry matches the original.
- [x] Restore a session with a single pane per window — no-op (layout replay skipped when `panes.Count <= 1`).
- [x] Restore a session with empty/missing `layout` field — gracefully skips the `select-layout` call.