### PR TITLE
fix(continuum): singleton-guard auto-save, drop Start-Job

### DIFF
--- a/psmux-continuum/plugin.conf
+++ b/psmux-continuum/plugin.conf
@@ -7,8 +7,9 @@
 #
 # NOTE: The auto_save.ps1 script runs a persistent loop (sleeping between
 # saves). run-shell executes it asynchronously so it won't block psmux.
-# If you attach multiple clients, multiple loops may start — this is
-# harmless since saves are idempotent.
+# It enforces a per-user singleton via PID file at
+# %LOCALAPPDATA%\psmux-continuum\auto_save.pid, so re-firing this hook on
+# every client attach will NOT spawn additional loops.
 
 # Start auto-save background loop on client attach (every 15 minutes)
 set-hook -g client-attached 'run-shell "pwsh -NoProfile -File \"~/.psmux/plugins/psmux-continuum/scripts/auto_save.ps1\" -IntervalMinutes 15"'

--- a/psmux-continuum/psmux-continuum.ps1
+++ b/psmux-continuum/psmux-continuum.ps1
@@ -33,8 +33,14 @@ if (-not (Test-Path $SCRIPTS_DIR)) {
 }
 
 # --- Create the auto-save background script ---
+# NOTE: The auto_save loop is a per-user singleton enforced by a PID file
+# at $env:LOCALAPPDATA\psmux-continuum\auto_save.pid. This means the
+# client-attached hook in plugin.conf can re-fire on every re-attach
+# without accumulating long-running pwsh processes — duplicate launches
+# detect the live owner and exit immediately.
 $autoSaveScript = @'
 #!/usr/bin/env pwsh
+# DO NOT EDIT — regenerated from psmux-continuum.ps1 on plugin load.
 # psmux-continuum: Background auto-save loop
 param(
     [int]$IntervalMinutes = 15
@@ -50,6 +56,45 @@ function Get-PsmuxBin {
     return 'psmux'
 }
 
+# --- Singleton guard: one auto-save loop per user ---
+$pidDir  = Join-Path $env:LOCALAPPDATA 'psmux-continuum'
+$pidFile = Join-Path $pidDir 'auto_save.pid'
+$logFile = Join-Path $pidDir 'auto_save.log'
+New-Item -ItemType Directory -Path $pidDir -Force -ErrorAction SilentlyContinue | Out-Null
+
+# Rotate the log if it grew past 256 KB. Add-Content reopens per write, so
+# concurrent invocations don't corrupt each other's writes.
+if ((Test-Path $logFile) -and ((Get-Item $logFile).Length -gt 262144)) {
+    Move-Item $logFile "$logFile.old" -Force -ErrorAction SilentlyContinue
+}
+
+function Log {
+    param([string]$Message, [string]$Level = 'INF')
+    try {
+        "[{0}] [{1}] [PID {2}] {3}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $Level, $PID, $Message |
+            Add-Content -Path $logFile -Encoding UTF8 -ErrorAction Stop
+    }
+    catch {}
+}
+
+# If a live owner already holds the PID file, defer.
+$existingPid = $null
+try {
+    $existingPid = (Get-Content $pidFile -Raw -ErrorAction Stop).Trim()
+}
+catch {}
+if ($existingPid -match '^\d+$') {
+    $existing = Get-Process -Id ([int]$existingPid) -ErrorAction SilentlyContinue
+    if ($existing -and ($existing.ProcessName -in @('pwsh','powershell'))) {
+        Log "auto-save already running (PID $existingPid), exiting."
+        exit 0
+    }
+}
+
+# Claim the slot
+"$PID" | Set-Content -Path $pidFile -Encoding UTF8 -Force
+Log "claimed singleton slot; interval=${IntervalMinutes}m"
+
 $PSMUX = Get-PsmuxBin
 
 # Find the resurrect save script
@@ -59,25 +104,59 @@ if (-not (Test-Path $saveScript)) {
 }
 
 if (-not (Test-Path $saveScript)) {
-    Write-Host "psmux-continuum: psmux-resurrect not found. Install it first." -ForegroundColor Red
+    Log "psmux-resurrect not found. Install it first." 'ERR'
+    Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
     exit 1
 }
 
 $IntervalSeconds = $IntervalMinutes * 60
+$iter = 0
 
-while ($true) {
-    Start-Sleep -Seconds $IntervalSeconds
+try {
+    while ($true) {
+        Start-Sleep -Seconds $IntervalSeconds
 
-    # Check if psmux server is still running
-    $sessions = & $PSMUX ls 2>&1 | Out-String
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "psmux-continuum: Server not running, stopping auto-save." -ForegroundColor Yellow
-        break
+        # Graceful supersede: if the PID file no longer points to us, exit.
+        $owner = $null
+        try {
+            $owner = (Get-Content $pidFile -Raw -ErrorAction Stop).Trim()
+        }
+        catch {}
+        if ($owner -ne "$PID") {
+            Log "superseded, exiting."
+            break
+        }
+
+        # Check if psmux server is still running
+        $sessions = & $PSMUX ls 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            Log "psmux server not running, stopping auto-save." 'WRN'
+            break
+        }
+
+        # Run the save; capture all streams (output, errors, warnings) into the log.
+        & pwsh -NoProfile -File $saveScript *>> $logFile
+        Log "auto-saved."
+
+        # Bound memory growth in this long-running loop
+        $iter++
+        if (($iter % 4) -eq 0) {
+            [GC]::Collect()
+            [GC]::WaitForPendingFinalizers()
+            [GC]::Collect()
+        }
     }
-
-    # Run the save
-    & pwsh -NoProfile -File $saveScript
-    Write-Host "psmux-continuum: Auto-saved at $(Get-Date -Format 'HH:mm:ss')" -ForegroundColor DarkGray
+}
+finally {
+    Log "exiting; releasing singleton slot."
+    # Release singleton slot only if we still own it
+    try {
+        $owner = (Get-Content $pidFile -Raw -ErrorAction Stop).Trim()
+        if ($owner -eq "$PID") {
+            Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+    catch {}
 }
 '@
 
@@ -86,6 +165,7 @@ Set-Content -Path (Join-Path $SCRIPTS_DIR 'auto_save.ps1') -Value $autoSaveScrip
 # --- Create the auto-restore script ---
 $autoRestoreScript = @'
 #!/usr/bin/env pwsh
+# DO NOT EDIT — regenerated from psmux-continuum.ps1 on plugin load.
 # psmux-continuum: Auto-restore on server start
 $ErrorActionPreference = 'Continue'
 
@@ -107,6 +187,7 @@ Set-Content -Path (Join-Path $SCRIPTS_DIR 'auto_restore.ps1') -Value $autoRestor
 # --- Create boot script ---
 $bootScript = @'
 #!/usr/bin/env pwsh
+# DO NOT EDIT — regenerated from psmux-continuum.ps1 on plugin load.
 # psmux-continuum: Register/unregister psmux auto-start on Windows login
 param(
     [switch]$Enable,
@@ -143,7 +224,7 @@ if ($Enable) {
 
 Set-Content -Path (Join-Path $SCRIPTS_DIR 'boot.ps1') -Value $bootScript -Force
 
-# --- Start auto-save background job ---
+# --- Start auto-save background loop ---
 $interval = 15  # Default 15 minutes
 
 # Try to read interval from psmux options
@@ -154,10 +235,11 @@ if ($intervalOpt -match '^\d+$') {
 
 if ($interval -gt 0) {
     $autoSavePath = Join-Path $SCRIPTS_DIR 'auto_save.ps1'
-    Start-Job -ScriptBlock {
-        param($script, $interval)
-        & pwsh -NoProfile -File $script -IntervalMinutes $interval
-    } -ArgumentList $autoSavePath, $interval | Out-Null
+    # Detached, hidden pwsh — single process, not a Start-Job wrapper.
+    # The singleton guard inside auto_save.ps1 makes repeated launches safe.
+    Start-Process -FilePath 'pwsh' `
+        -ArgumentList @('-NoProfile','-File',$autoSavePath,'-IntervalMinutes',"$interval") `
+        -WindowStyle Hidden | Out-Null
 }
 
 # --- Auto-restore on first load ---

--- a/psmux-continuum/scripts/auto_restore.ps1
+++ b/psmux-continuum/scripts/auto_restore.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+# DO NOT EDIT — regenerated from psmux-continuum.ps1 on plugin load.
 # psmux-continuum: Auto-restore on server start
 $ErrorActionPreference = 'Continue'
 

--- a/psmux-continuum/scripts/auto_save.ps1
+++ b/psmux-continuum/scripts/auto_save.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+# DO NOT EDIT — regenerated from psmux-continuum.ps1 on plugin load.
 # psmux-continuum: Background auto-save loop
 param(
     [int]$IntervalMinutes = 15
@@ -14,6 +15,45 @@ function Get-PsmuxBin {
     return 'psmux'
 }
 
+# --- Singleton guard: one auto-save loop per user ---
+$pidDir  = Join-Path $env:LOCALAPPDATA 'psmux-continuum'
+$pidFile = Join-Path $pidDir 'auto_save.pid'
+$logFile = Join-Path $pidDir 'auto_save.log'
+New-Item -ItemType Directory -Path $pidDir -Force -ErrorAction SilentlyContinue | Out-Null
+
+# Rotate the log if it grew past 256 KB. Add-Content reopens per write, so
+# concurrent invocations don't corrupt each other's writes.
+if ((Test-Path $logFile) -and ((Get-Item $logFile).Length -gt 262144)) {
+    Move-Item $logFile "$logFile.old" -Force -ErrorAction SilentlyContinue
+}
+
+function Log {
+    param([string]$Message, [string]$Level = 'INF')
+    try {
+        "[{0}] [{1}] [PID {2}] {3}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $Level, $PID, $Message |
+            Add-Content -Path $logFile -Encoding UTF8 -ErrorAction Stop
+    }
+    catch {}
+}
+
+# If a live owner already holds the PID file, defer.
+$existingPid = $null
+try {
+    $existingPid = (Get-Content $pidFile -Raw -ErrorAction Stop).Trim()
+}
+catch {}
+if ($existingPid -match '^\d+$') {
+    $existing = Get-Process -Id ([int]$existingPid) -ErrorAction SilentlyContinue
+    if ($existing -and ($existing.ProcessName -in @('pwsh','powershell'))) {
+        Log "auto-save already running (PID $existingPid), exiting."
+        exit 0
+    }
+}
+
+# Claim the slot
+"$PID" | Set-Content -Path $pidFile -Encoding UTF8 -Force
+Log "claimed singleton slot; interval=${IntervalMinutes}m"
+
 $PSMUX = Get-PsmuxBin
 
 # Find the resurrect save script
@@ -23,23 +63,57 @@ if (-not (Test-Path $saveScript)) {
 }
 
 if (-not (Test-Path $saveScript)) {
-    Write-Host "psmux-continuum: psmux-resurrect not found. Install it first." -ForegroundColor Red
+    Log "psmux-resurrect not found. Install it first." 'ERR'
+    Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
     exit 1
 }
 
 $IntervalSeconds = $IntervalMinutes * 60
+$iter = 0
 
-while ($true) {
-    Start-Sleep -Seconds $IntervalSeconds
+try {
+    while ($true) {
+        Start-Sleep -Seconds $IntervalSeconds
 
-    # Check if psmux server is still running
-    $sessions = & $PSMUX ls 2>&1 | Out-String
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "psmux-continuum: Server not running, stopping auto-save." -ForegroundColor Yellow
-        break
+        # Graceful supersede: if the PID file no longer points to us, exit.
+        $owner = $null
+        try {
+            $owner = (Get-Content $pidFile -Raw -ErrorAction Stop).Trim()
+        }
+        catch {}
+        if ($owner -ne "$PID") {
+            Log "superseded, exiting."
+            break
+        }
+
+        # Check if psmux server is still running
+        $sessions = & $PSMUX ls 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            Log "psmux server not running, stopping auto-save." 'WRN'
+            break
+        }
+
+        # Run the save; capture all streams (output, errors, warnings) into the log.
+        & pwsh -NoProfile -File $saveScript *>> $logFile
+        Log "auto-saved."
+
+        # Bound memory growth in this long-running loop
+        $iter++
+        if (($iter % 4) -eq 0) {
+            [GC]::Collect()
+            [GC]::WaitForPendingFinalizers()
+            [GC]::Collect()
+        }
     }
-
-    # Run the save
-    & pwsh -NoProfile -File $saveScript
-    Write-Host "psmux-continuum: Auto-saved at $(Get-Date -Format 'HH:mm:ss')" -ForegroundColor DarkGray
+}
+finally {
+    Log "exiting; releasing singleton slot."
+    # Release singleton slot only if we still own it
+    try {
+        $owner = (Get-Content $pidFile -Raw -ErrorAction Stop).Trim()
+        if ($owner -eq "$PID") {
+            Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+    catch {}
 }

--- a/psmux-continuum/scripts/boot.ps1
+++ b/psmux-continuum/scripts/boot.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+# DO NOT EDIT — regenerated from psmux-continuum.ps1 on plugin load.
 # psmux-continuum: Register/unregister psmux auto-start on Windows login
 param(
     [switch]$Enable,


### PR DESCRIPTION
## Summary

The `client-attached` hook in `plugin.conf` and the `Start-Job` spawn in `psmux-continuum.ps1` each launched a fresh persistent `pwsh` loop on every re-attach / plugin load with **no de-duplication**. Over days this accumulated long-running ~100 MB pwsh processes whose memory continued to grow. The misleading `plugin.conf` comment even acknowledged the duplication ("multiple loops may start — this is harmless since saves are idempotent") — but each loop is a persistent background process consuming real memory.

After running locally for ~8 days my session had **5 zombie `auto_save.ps1` loops totaling ~580 MB**; the oldest had been alive for over a week and grown from ~100 MB to 124 MB.

## What changed

### Singleton enforcement
`auto_save.ps1` now claims a PID file at `%LOCALAPPDATA%\psmux-continuum\auto_save.pid`:

- On launch, if a live `pwsh` / `powershell` PID owns the file, exit `0` immediately. The `client-attached` hook is now safe to re-fire on every attach.
- Stale PID detection: if the recorded PID isn't a live `pwsh`, the new launch claims the slot.
- The loop releases the slot via `try { … } finally { … }` and self-exits gracefully if superseded (per-iteration check that the PID file still points at us).
- Periodic `[GC]::Collect()` every 4 iterations bounds long-run memory growth.

### Single-process spawn
Replaced `Start-Job` with `Start-Process -WindowStyle Hidden`. `Start-Job` spawned an outer scriptblock-host pwsh that itself spawned the inner `pwsh -File auto_save.ps1`, so every plugin load created **two** pwsh processes that never reaped (you could see this in the zombie list — the outer was the parent of the inner). `Start-Process` gives a single detached pwsh; the singleton guard inside the loop makes repeat launches safe.

### Diagnosable logging
`Start-Process -WindowStyle Hidden` has no console attached, so the loop's `Write-Host` output was previously discarded. Added a `Log` helper that timestamps each line with `[INF]` / `[WRN]` / `[ERR]` and appends to `%LOCALAPPDATA%\psmux-continuum\auto_save.log`, with 256 KB rotation to a `.old` sibling file. Per-write `Add-Content` keeps file locks brief, so concurrent ephemeral pwshs (the singleton-rejected ones) don't corrupt each other's writes. The `& pwsh -File save.ps1` invocation now redirects all six PowerShell streams (`*>> \$logFile`), so `save.ps1` errors land in the log too.

Sample log output:

```
[2026-05-02 14:30:01] [INF] [PID 1234] claimed singleton slot; interval=15m
[2026-05-02 14:45:01] [INF] [PID 1234] auto-saved.
[2026-05-02 15:00:01] [WRN] [PID 1234] psmux server not running, stopping auto-save.
[2026-05-02 15:00:01] [INF] [PID 1234] exiting; releasing singleton slot.
```

### Conventions
- All three regenerated helper scripts (\`auto_save.ps1\`, \`auto_restore.ps1\`, \`boot.ps1\`) now carry a \`# DO NOT EDIT — regenerated from psmux-continuum.ps1 on plugin load\` header so contributors edit the heredoc, not the artifact.
- The misleading \`plugin.conf\` comment is corrected to describe the new singleton behavior.
- Heredoc and standalone artifact are byte-identical (regeneration is a no-op against this checkout).

## Test plan

- [x] Both \`psmux-continuum.ps1\` and \`scripts/auto_save.ps1\` parse (verified via \`PSParser::Tokenize\`).
- [x] All three heredoc bodies in \`psmux-continuum.ps1\` match their \`scripts/*.ps1\` artifact byte-for-byte (verified via AST extraction + string compare).
- [x] Start a psmux session, reattach a client 3+ times, then check process list — expect exactly one \`auto_save.ps1\` pwsh.
- [x] Wait ~16 minutes; verify \`%LOCALAPPDATA%\psmux-continuum\auto_save.log\` contains an \`[INF] auto-saved.\` entry.
- [x] Stop the psmux server; expect the loop to log \`[WRN] psmux server not running, stopping auto-save.\` and exit, releasing the PID file.
- [x] Confirm no \`auto_save.ps1\` zombies remain across logout/login cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)