### PR TITLE
fix(continuum): honor @continuum-restore option for auto-restore on server start

### DIFF
--- a/psmux-continuum/plugin.conf
+++ b/psmux-continuum/plugin.conf
@@ -13,10 +13,17 @@
 # Start auto-save background loop on client attach (every 15 minutes)
 set-hook -g client-attached 'run-shell "pwsh -NoProfile -File \"~/.psmux/plugins/psmux-continuum/scripts/auto_save.ps1\" -IntervalMinutes 15"'
 
-# --- Auto-restore (disabled by default) ---
-# Uncomment the following line to auto-restore the last saved session
-# when a new session is created:
-# set-hook -g after-new-session 'run-shell "pwsh -NoProfile -File \"~/.psmux/plugins/psmux-continuum/scripts/auto_restore.ps1\""'
+# --- Auto-restore (opt-in via @continuum-restore 'on') ---
+# The hook is always registered; auto_restore.ps1 reads @continuum-restore
+# at exec time and exits without doing anything when the option is not 'on'.
+# This makes the option behave as documented in the README without requiring
+# users to edit plugin.conf.
+#
+# We use 'session-created' rather than 'after-new-session' because psmux only
+# fires the latter for sessions created AFTER the server is established;
+# the very first session in a fresh server (the one we need to trigger
+# auto-restore) does not fire after-new-session.
+set-hook -g session-created 'run-shell "pwsh -NoProfile -File \"~/.psmux/plugins/psmux-continuum/scripts/auto_restore.ps1\""'
 
 # --- Auto-boot (disabled by default) ---
 # To enable psmux auto-start on Windows login, run manually:

--- a/psmux-continuum/psmux-continuum.ps1
+++ b/psmux-continuum/psmux-continuum.ps1
@@ -89,6 +89,27 @@ $autoRestoreScript = @'
 # psmux-continuum: Auto-restore on server start
 $ErrorActionPreference = 'Continue'
 
+function Get-PsmuxBin {
+    foreach ($n in @('psmux','pmux','tmux')) {
+        $b = Get-Command $n -ErrorAction SilentlyContinue
+        if ($b) { return $b.Source }
+    }
+    return 'psmux'
+}
+
+# Opt-in via @continuum-restore 'on'. The plugin.conf hook is registered
+# unconditionally; this script is the option gate, evaluated at exec time.
+$PSMUX = Get-PsmuxBin
+$restoreOpt = (& $PSMUX show-options -gv '@continuum-restore' 2>&1 | Out-String).Trim()
+if ($restoreOpt -ne 'on') { exit 0 }
+
+# Fire at most once per psmux server lifetime. The hook is on session-created
+# and restore.ps1 itself calls new-session for each saved session, so without
+# this guard the hook would re-enter for every restored session.
+$firedOpt = (& $PSMUX show-options -gv '@continuum-restore-fired' 2>&1 | Out-String).Trim()
+if ($firedOpt -eq 'on') { exit 0 }
+& $PSMUX set-option -g '@continuum-restore-fired' 'on' 2>&1 | Out-Null
+
 $restoreScript = Join-Path $PSScriptRoot '..\..\psmux-resurrect\scripts\restore.ps1'
 if (-not (Test-Path $restoreScript)) {
     $restoreScript = Join-Path $env:USERPROFILE '.psmux\plugins\psmux-resurrect\scripts\restore.ps1'

--- a/psmux-continuum/scripts/auto_restore.ps1
+++ b/psmux-continuum/scripts/auto_restore.ps1
@@ -2,6 +2,27 @@
 # psmux-continuum: Auto-restore on server start
 $ErrorActionPreference = 'Continue'
 
+function Get-PsmuxBin {
+    foreach ($n in @('psmux','pmux','tmux')) {
+        $b = Get-Command $n -ErrorAction SilentlyContinue
+        if ($b) { return $b.Source }
+    }
+    return 'psmux'
+}
+
+# Opt-in via @continuum-restore 'on'. The plugin.conf hook is registered
+# unconditionally; this script is the option gate, evaluated at exec time.
+$PSMUX = Get-PsmuxBin
+$restoreOpt = (& $PSMUX show-options -gv '@continuum-restore' 2>&1 | Out-String).Trim()
+if ($restoreOpt -ne 'on') { exit 0 }
+
+# Fire at most once per psmux server lifetime. The hook is on session-created
+# and restore.ps1 itself calls new-session for each saved session, so without
+# this guard the hook would re-enter for every restored session.
+$firedOpt = (& $PSMUX show-options -gv '@continuum-restore-fired' 2>&1 | Out-String).Trim()
+if ($firedOpt -eq 'on') { exit 0 }
+& $PSMUX set-option -g '@continuum-restore-fired' 'on' 2>&1 | Out-Null
+
 $restoreScript = Join-Path $PSScriptRoot '..\..\psmux-resurrect\scripts\restore.ps1'
 if (-not (Test-Path $restoreScript)) {
     $restoreScript = Join-Path $env:USERPROFILE '.psmux\plugins\psmux-resurrect\scripts\restore.ps1'


### PR DESCRIPTION
## Summary

`set -g @continuum-restore 'on'` is documented in `psmux-continuum/README.md` as "auto-restore on psmux server start", but the option is silently ignored. Auto-save works; auto-restore never fires. After a server restart users get a fresh empty session, and ~15 min later the auto-save loop overwrites the `last` pointer with that empty state, pruning the recovery target.

This bit me after an unexpected reboot; saved session was on disk, `last` had been clobbered to point at an empty save, and nothing fired on startup.

## Root cause

Two entry points with what appears to be disjoint feature sets:

| Option | `psmux-continuum.ps1` | `plugin.conf` |
|---|---|---|
| `@continuum-restore` | honored (lines 163–168) | line 19 commented out |
| `@continuum-save-interval` | honored | hardcoded `15` |
| `@continuum-boot` | honored | not handled |

`ppm.ps1` (lines 391–398) deliberately skips `.ps1` entry points when `plugin.conf` exists, so the only code that reads `@continuum-*` options never runs. Only `plugin.conf` is sourced and it has the restore hook commented out.

**Empirical evidence on a real install:**
```
$ psmux show-options -g | findstr @continuum
@continuum-restore "on"

$ psmux show-hooks -g
client-attached -> run-shell "...auto_save.ps1 ..."
# (no restore hook registered)
```

## Second bug found while fixing this

The commented-out line uses `after-new-session`. Live hook-probe on a fresh psmux server:

```
after-new-session  => no
session-created    => FIRED
client-attached    => FIRED
```

`after-new-session` does **not** fire on the first session creation in a fresh server, only on subsequent ones. So simply uncommenting that line would still have left auto-restore broken after one scenario where it really matters (server restart). This PR uses `session-created` instead.

## Fix

- `plugin.conf`: unconditionally register the `session-created` hook -> `auto_restore.ps1`.
- `auto_restore.ps1`: read `@continuum-restore` at exec time, exit early if not `on`. Keeps `plugin.conf` free of nested `if-shell` quoting and evaluates the option at hook-fire time (robust to option-set ordering vs. config sourcing).
- Add a `@continuum-restore-fired` one-shot marker. Without this guard the hook re-enters for every `psmux new-session` call that `restore.ps1` itself makes.
- Heredoc in `psmux-continuum.ps1` kept byte-identical to `scripts/auto_restore.ps1` to preserve the existing regeneration invariant.

## Validation

- ✅ `session-created` fires on first session - live-probed.
- ✅ `after-new-session` does not fire on first session - live-probed.
- ✅ Hook registers correctly via patched `plugin.conf` - verified with `psmux show-hooks -g`.
- ✅ Opt-out path: when `@continuum-restore` is unset or `off`, `auto_restore.ps1` exits early without invoking `restore.ps1` or setting the fired marker - live-tested.
- ✅ Both `.ps1` files parse cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`).
- ✅ Heredoc and `scripts/auto_restore.ps1` are byte-identical (AST-extracted + string-compared).

## Overlap with PR #13

PR #13 (singleton-guard auto-save) touches the same files. This PR's diff is orthogonal and trivially rebases either way.
