### PR TITLE
fix(resurrect): scrub PSMUX_SESSION/TMUX env so restore.ps1 can run from inside a psmux pane

### DIFF
--- a/psmux-resurrect/scripts/restore.ps1
+++ b/psmux-resurrect/scripts/restore.ps1
@@ -5,6 +5,19 @@
 #           window flags, active window selection
 $ErrorActionPreference = 'Continue'
 
+# Detach from any inherited psmux/tmux nesting context. This script intentionally
+# creates new sessions on the running server; we are not nesting a child psmux
+# inside a parent. Without this, child `psmux new-session` invocations refuse
+# to run with "sessions should be nested with care, unset PSMUX_SESSION to force"
+# whenever restore.ps1 is invoked from a context that inherited PSMUX_SESSION,
+# TMUX, etc. - which includes any manual invocation from a pwsh inside a running
+# psmux pane (Prefix+Ctrl-r works because psmux strips these for hook execution,
+# but `& restore.ps1` from the cmdline does not).
+$env:PSMUX_SESSION = $null
+$env:PSMUX_TARGET_SESSION = $null
+$env:TMUX = $null
+$env:TMUX_PANE = $null
+
 function Get-PsmuxBin {
     foreach ($n in @('psmux','pmux','tmux')) {
         $b = Get-Command $n -ErrorAction SilentlyContinue


### PR DESCRIPTION
restore.ps1 calls `psmux new-session` for each saved session. When the script is invoked from a context that inherited PSMUX_SESSION, PSMUX_TARGET_SESSION, TMUX, or TMUX_PANE - which is the case for any direct invocation from a pwsh inside a running psmux pane, or any cmdline run of `~/.psmux/plugins/psmux-resurrect/scripts/restore.ps1` from inside a session - the child psmux refuses to nest:

    psmux: sessions should be nested with care, unset PSMUX_SESSION to force

The script's wait loop then times out and reports "Failed to create session 'X'", with no other diagnostic.

This bites users any time auto-restore needs to be retriggered (e.g. after the @continuum-restore-fired marker is set, or when manually running restore from the command line). The Prefix+Ctrl-r keybinding works because psmux strips these env vars when executing hook commands - but direct invocation does not.

Fix: at the top of restore.ps1, null out PSMUX_SESSION, PSMUX_TARGET_SESSION, TMUX, and TMUX_PANE in the script's process scope. This script intentionally creates new sessions on the running server - we are not nesting a child psmux inside a parent. The nesting protection is irrelevant here.

Scope: only the restore script's process. No other process or psmux invocation is affected.

Validation
==========

Live test from inside a running psmux pane (PSMUX_SESSION=main, TMUX=/tmp/psmux-54964/default,55936,0):
* Created a temp save with a unique session name pointing at @resurrect-dir override.
* Invoked patched restore.ps1 directly (no wrapper, no env scrub at the call site).
* Verified: temp 2-window session was created, parent sessions remained intact, @resurrect-dir was cleanly reset.

Without this fix, the same invocation produces "Failed to create session" and the temp session is never created.