### PR TITLE
fix(resurrect): bypass psmux nesting guard via PSMUX_ALLOW_NESTING

### DIFF
--- a/psmux-resurrect/scripts/restore.ps1
+++ b/psmux-resurrect/scripts/restore.ps1
@@ -5,6 +5,13 @@
 #           window flags, active window selection
 $ErrorActionPreference = 'Continue'
 
+# psmux refuses `new-session` when PSMUX_SESSION/PSMUX_ACTIVE is set
+# (psmux/src/main.rs:627), even with -d which cannot nest a UI. This
+# script only issues detached new-session calls, so opt out of the guard
+# via the documented override (psmux/src/main.rs:3120). Preserves
+# PSMUX_TARGET_SESSION (server routing) and tool-detection signals.
+$env:PSMUX_ALLOW_NESTING = '1'
+
 function Get-PsmuxBin {
     foreach ($n in @('psmux','pmux','tmux')) {
         $b = Get-Command $n -ErrorAction SilentlyContinue

--- a/tests/test_resurrect_e2e.ps1
+++ b/tests/test_resurrect_e2e.ps1
@@ -371,11 +371,59 @@ if ($winCountBefore -eq $winCountAfter) { Write-Pass "Idempotent: session unchan
 else { Write-Fail "Session modified on re-restore: $winCountBefore -> $winCountAfter" }
 
 # ===================================================================
+# PART 3b: Restore from nested psmux context
+# ===================================================================
+Write-Host "`n[Test 21] Restore tolerates inherited PSMUX_SESSION/TMUX context" -ForegroundColor Yellow
+# Regression: when restore.ps1 inherits PSMUX_SESSION / PSMUX_TARGET_SESSION /
+# TMUX / TMUX_PANE from its parent - which happens for any direct invocation
+# from a pwsh running inside a psmux pane - psmux's nesting guard refused the
+# inner `new-session -d` calls with "sessions should be nested with care".
+# restore.ps1 sets PSMUX_ALLOW_NESTING=1 in its own process scope to opt out
+# of that guard while preserving PSMUX_TARGET_SESSION and tool-detection vars.
+
+# Tear down the live session so restore has work to do
+& $PSMUX kill-session -t $SESSION 2>&1 | Out-Null
+Start-Sleep -Seconds 2
+Remove-Item "$psmuxDir\$SESSION.*" -Force -EA SilentlyContinue
+
+& $PSMUX has-session -t $SESSION 2>$null
+if ($LASTEXITCODE -eq 0) { Write-Fail "Setup: could not kill $SESSION before nested-context test" }
+
+# Simulate the env a pwsh sees from inside a running psmux pane.
+# These get inherited by the child `pwsh -File restore.ps1` process below.
+$prevEnv = @{
+    PSMUX_SESSION        = $env:PSMUX_SESSION
+    PSMUX_TARGET_SESSION = $env:PSMUX_TARGET_SESSION
+    TMUX                 = $env:TMUX
+    TMUX_PANE            = $env:TMUX_PANE
+}
+$env:PSMUX_SESSION        = 'parent_pane_session'
+$env:PSMUX_TARGET_SESSION = 'parent_pane_session'
+$env:TMUX                 = '/tmp/psmux-fake/default,1234,0'
+$env:TMUX_PANE            = '%0'
+
+try {
+    & pwsh -NoProfile -ExecutionPolicy Bypass -File $RESTORE_SCRIPT 2>&1 | Out-Null
+    Start-Sleep -Seconds 5
+
+    if (Wait-Session $SESSION 20000) {
+        Write-Pass "Restore succeeded under inherited PSMUX_SESSION/TMUX"
+    } else {
+        Write-Fail "Restore failed under inherited PSMUX_SESSION/TMUX (PSMUX_ALLOW_NESTING bypass regression)"
+    }
+} finally {
+    $env:PSMUX_SESSION        = $prevEnv.PSMUX_SESSION
+    $env:PSMUX_TARGET_SESSION = $prevEnv.PSMUX_TARGET_SESSION
+    $env:TMUX                 = $prevEnv.TMUX
+    $env:TMUX_PANE            = $prevEnv.TMUX_PANE
+}
+
+# ===================================================================
 # PART 4: Backup Rotation Test
 # ===================================================================
 Write-Host "`n--- PART 4: Backup Rotation ---" -ForegroundColor Cyan
 
-Write-Host "`n[Test 21] Backup rotation keeps max 20" -ForegroundColor Yellow
+Write-Host "`n[Test 22] Backup rotation keeps max 20" -ForegroundColor Yellow
 # Create 25 fake save files
 for ($i = 1; $i -le 25; $i++) {
     $fakeTs = "20250101_{0:D6}" -f $i
@@ -412,7 +460,7 @@ $SESSION_TUI = "resurrect_tui_proof"
 & $PSMUX kill-session -t $SESSION_TUI 2>&1 | Out-Null
 Start-Sleep -Milliseconds 500
 
-Write-Host "`n[Test 22] TUI: Save and restore with real visible window" -ForegroundColor Yellow
+Write-Host "`n[Test 23] TUI: Save and restore with real visible window" -ForegroundColor Yellow
 
 # Launch a visible psmux window (this also starts a server if needed)
 $proc = Start-Process -FilePath $PSMUX -ArgumentList "new-session","-s",$SESSION_TUI -PassThru
@@ -482,7 +530,7 @@ Remove-Item "$psmuxDir\$TCP_SESSION.*" -Force -EA SilentlyContinue
 if (-not (Wait-Session $TCP_SESSION)) {
     Write-Fail "TCP test session failed to create"
 } else {
-    Write-Host "`n[Test 23] TCP: Commands work on restored session" -ForegroundColor Yellow
+    Write-Host "`n[Test 24] TCP: Commands work on restored session" -ForegroundColor Yellow
 
     # Save, kill, restore
     & pwsh -NoProfile -ExecutionPolicy Bypass -File $SAVE_SCRIPT 2>&1 | Out-Null


### PR DESCRIPTION
## TL;DR

Follow-up to #17 by @MattKotsenas, which spots the same bug.

That PR nulls four env vars to dodge psmux's nesting guard. This one flips a single flag instead and leaves the env vars alone.

Same fix, fewer side effects. The flag is psmux's own documented escape hatch for "I know I'm not nesting" — exactly what `new-session -d` is.

## Summary

`restore.ps1` calls `psmux new-session -d` for each saved session. When invoked from a context that inherits `PSMUX_SESSION`/`TMUX` (any direct `pwsh` run from inside a running psmux pane, or `restore.ps1` run from the cmdline of an existing session), psmux's nesting guard refuses the call:

```
psmux: sessions should be nested with care, unset PSMUX_SESSION to force
```

The wait loop then times out with "Failed to create session 'X'" and no further diagnostic. `Prefix+Ctrl-r` works only because psmux strips these vars when executing hook commands; direct invocation does not.

## Fix

`new-session -d` cannot actually nest a UI — nothing attaches. psmux ships a documented override for exactly this case: `PSMUX_ALLOW_NESTING=1`, checked at the nesting guard (`psmux/src/main.rs:627`) and documented inline (`main.rs:3120` — *"Override with PSMUX_ALLOW_NESTING=1 if nesting is intentional."*).

Setting `$env:PSMUX_ALLOW_NESTING = '1'` at the top of `restore.ps1`:

- Bypasses the guard for the script's child `psmux` calls
- Preserves `PSMUX_TARGET_SESSION` (server routing for multi-server setups)
- Preserves `PSMUX_SESSION` / `TMUX` (signals downstream tools sniff to detect they are inside a multiplexer — Claude Code, prompt themes, etc.)
- Declares intent ("this is not nesting") instead of hiding the parent context

## Relation to #17

#17 addresses the same bug by nulling four env vars (`PSMUX_SESSION`, `PSMUX_TARGET_SESSION`, `TMUX`, `TMUX_PANE`) at the top of `restore.ps1`. That works but has two downsides:

1. `PSMUX_TARGET_SESSION` is psmux's server-routing signal for child commands. In a multi-server setup, nulling it could route restored sessions to the wrong server.
2. `PSMUX_SESSION`/`TMUX` are how downstream tools detect they're in a multiplexer. They get re-set by psmux when it spawns the restored pane shells, but the scrub is collateral that this fix avoids.

Discussion: https://github.com/psmux/psmux-plugins/pull/17#issuecomment-4461773507

## Test plan

- [x] `tests/test_resurrect_e2e.ps1` adds `[Test 21]` that simulates inherited `PSMUX_SESSION` / `PSMUX_TARGET_SESSION` / `TMUX` / `TMUX_PANE`, runs `restore.ps1` via a child `pwsh -File`, and asserts the session is recreated. Without the fix the assertion fails (nesting guard refuses); with it the test passes.
- [x] Manual: confirmed `psmux new-session -d -s <name>` succeeds with `PSMUX_ALLOW_NESTING=1` set in env even when `PSMUX_SESSION`/`TMUX` are populated by the surrounding pane.
- [x] Reviewer: run the full e2e suite (`tests/test_resurrect_e2e.ps1`) and confirm no regression in Tests 22–24 (renumbered: backup rotation, TUI, TCP).