### PR TITLE
fix(resurrect): skip empty-session snapshots and preserve last pointer

### DIFF
--- a/psmux-resurrect/scripts/save.ps1
+++ b/psmux-resurrect/scripts/save.ps1
@@ -130,6 +130,23 @@ foreach ($line in ($sessionLines -split "`n")) {
     $env_data.sessions += $sessionData
 }
 
+# Guard: never persist a 0-session snapshot.
+# psmux returns exit 0 with empty output when no server is running (which is also why the
+# capture loop above retries on empty), so a 0-session capture almost always means "the
+# server is down", not "the user has no sessions" -- tmux/psmux tears the server down when
+# its last session goes. Writing it would create a useless restore point AND repoint 'last'
+# to it; the 20-slot rotation then evicts the good snapshots, silently destroying the
+# ability to resurrect. We bail here -- after the capture loop but before dedup, the write
+# and the 'last' repoint -- so an empty capture has no side effects.
+# (Known limitation: a PARTIAL capture -- a session reported mid-startup with incomplete
+# windows/panes -- has >=1 session, so it passes this guard and is still written. Closing
+# that needs an expected-session-count signal we don't have here; tracked as a follow-up.)
+if (@($env_data.sessions).Count -eq 0) {
+    & $PSMUX display-message "No sessions to save, skipping." 2>&1 | Out-Null
+    Write-Host "psmux-resurrect: No sessions captured, skipping save (server likely down)." -ForegroundColor Yellow
+    exit 0
+}
+
 # Save to JSON
 $jsonContent = $env_data | ConvertTo-Json -Depth 10
 

--- a/tests/test_resurrect_guard.ps1
+++ b/tests/test_resurrect_guard.ps1
@@ -1,0 +1,135 @@
+#!/usr/bin/env pwsh
+# =============================================================================
+# psmux-resurrect: empty-snapshot guard regression test (PR1)
+# =============================================================================
+# Hermetic by design: needs NEITHER a running psmux server NOR a real psmux
+# binary. A fake-psmux shim simulates "server up" / "server down" / "partial",
+# and $env:USERPROFILE is redirected to a temp dir, so this NEVER touches a real
+# dev's ~/.psmux/resurrect (unlike test_resurrect*.ps1, which wipe it).
+#
+# Covers the save.ps1 0-session guard:
+#   - server down (0 sessions): no snapshot written, `last` preserved byte-identical
+#     (both with a prior good `last` and on a virgin dir -> guard, not dedup).
+#   - server up (>=1 session): still writes + repoints (no false skip).
+#   - KNOWN GAP (characterization, not a fix): a PARTIAL capture (a session reported
+#     but mid-startup with no windows yet) is NOT caught by the 0-session guard -- it
+#     has >=1 session so it is still written, degraded. Pinned so a future fix has a
+#     target. Tracked as a follow-up in the PR.
+# (The continuum break-on-empty / here-string drift asserts live in
+#  test_continuum_guard.ps1 so this file stays green on the resurrect-only PR branch.)
+# Run:  pwsh -File tests/test_resurrect_guard.ps1
+# =============================================================================
+$ErrorActionPreference = 'Continue'
+
+$pass = 0; $fail = 0
+function Check($name, $cond, $detail = '') {
+    if ($cond) { Write-Host "  PASS: $name" -ForegroundColor Green; $script:pass++ }
+    else       { Write-Host "  FAIL: $name$(if($detail){' >> ' + $detail})" -ForegroundColor Red; $script:fail++ }
+}
+
+$PLUGIN_ROOT = Split-Path $PSScriptRoot -Parent
+$SAVE_SCRIPT = Join-Path $PLUGIN_ROOT 'psmux-resurrect\scripts\save.ps1'
+
+Write-Host "`n=== psmux-resurrect empty-snapshot guard test (hermetic) ===" -ForegroundColor Magenta
+
+# --- sandbox + fake-psmux shim ---------------------------------------------
+$sandbox   = Join-Path ([IO.Path]::GetTempPath()) ("psmux-guard-{0}" -f ([guid]::NewGuid().ToString('N')))
+$resurrect = Join-Path $sandbox '.psmux\resurrect'
+$binDir    = Join-Path $sandbox 'bin'
+New-Item -ItemType Directory -Path $resurrect, $binDir -Force | Out-Null
+# Fake psmux is a .ps1 resolved via PATHEXT (NOT a .cmd bridge): a cmd `%*` bridge would
+# let cmd interpret the `|` in psmux's `-F '#{...}|#{...}'` format strings as a pipe and
+# mangle list-windows/list-panes. Invoke-Save adds .PS1 to PATHEXT so `Get-Command psmux`
+# (in save.ps1's Get-PsmuxBin) resolves psmux.ps1 and args pass through PowerShell intact.
+
+function Set-FakePsmux([ValidateSet('down','up','partial')][string]$Mode) {
+    $impl = Join-Path $binDir 'psmux.ps1'
+    switch ($Mode) {
+        'down' { Set-Content $impl 'exit 0' -Encoding UTF8 }   # exit 0 + empty == no server (real psmux behaviour)
+        'up'   { Set-Content $impl @'
+$a = $args
+if ($a[0] -eq 'list-sessions') { 'alpha'; exit 0 }
+if ($a[0] -eq 'list-windows')  { '0|main|1|c2be,80x24,0,0,1|0|'; exit 0 }
+if ($a[0] -eq 'list-panes')    { '0|C:\Users\Public|1|title|pwsh'; exit 0 }
+exit 0
+'@ -Encoding UTF8 }
+        'partial' { Set-Content $impl @'
+# Two sessions reported, but 'beta' is mid-startup: it has no windows yet.
+# A real partial capture -- distinct from 'up' -- to characterize the known gap.
+$a = $args
+if ($a[0] -eq 'list-sessions') { 'alpha'; 'beta'; exit 0 }
+if ($a[0] -eq 'list-windows') {
+    if ($a -contains 'beta') { exit 0 }                       # beta: no windows yet
+    '0|main|1|c2be,80x24,0,0,1|0|'; exit 0                     # alpha: one window
+}
+if ($a[0] -eq 'list-panes') { '0|C:\Users\Public|1|title|pwsh'; exit 0 }
+exit 0
+'@ -Encoding UTF8 }
+    }
+}
+function Invoke-Save {
+    $u = $env:USERPROFILE; $p = $env:PATH; $x = $env:PATHEXT
+    try {
+        $env:USERPROFILE = $sandbox
+        $env:PATH = "$binDir;$env:PATH"
+        $env:PATHEXT = ".PS1;$env:PATHEXT"   # so Get-Command psmux resolves psmux.ps1
+        & pwsh -NoProfile -File $SAVE_SCRIPT *>$null
+    }
+    finally { $env:USERPROFILE = $u; $env:PATH = $p; $env:PATHEXT = $x }
+}
+function SnapCount { @(Get-ChildItem $resurrect -Filter 'psmux_resurrect_*.json' -ErrorAction SilentlyContinue).Count }
+function Newest-Snap { Get-ChildItem $resurrect -Filter 'psmux_resurrect_*.json' -ErrorAction SilentlyContinue | Sort-Object Name -Descending | Select-Object -First 1 }
+function Reset-GoodLast {
+    Get-ChildItem $resurrect -File -ErrorAction SilentlyContinue | Remove-Item -Force
+    $good = Join-Path $resurrect 'psmux_resurrect_20260101_120000.json'
+    '{ "version":2, "timestamp":"20260101_120000", "sessions":[{"name":"real","windows":[]}] }' | Set-Content $good -Encoding UTF8
+    $good | Set-Content (Join-Path $resurrect 'last') -Encoding UTF8
+}
+
+try {
+    # 1. server DOWN, a good `last` exists -> must skip + preserve last
+    Reset-GoodLast
+    Set-FakePsmux 'down'
+    $before = SnapCount
+    $lastBefore = Get-Content (Join-Path $resurrect 'last') -Raw
+    Invoke-Save
+    Check "0-session capture writes no new snapshot" ((SnapCount) -eq $before) "before=$before after=$(SnapCount)"
+    Check "0-session capture preserves 'last' (byte-identical)" ((Get-Content (Join-Path $resurrect 'last') -Raw) -ceq $lastBefore)
+
+    # 2. server DOWN, virgin dir (no prior last) -> still no write (guard, not dedup)
+    Get-ChildItem $resurrect -File -ErrorAction SilentlyContinue | Remove-Item -Force
+    Set-FakePsmux 'down'
+    Invoke-Save
+    Check "0-session on a virgin dir writes nothing (guard, not dedup)" ((SnapCount) -eq 0)
+    Check "0-session on a virgin dir creates no 'last'" (-not (Test-Path (Join-Path $resurrect 'last')))
+
+    # 3. positive control: a session exists -> must write + repoint last
+    Reset-GoodLast
+    Set-FakePsmux 'up'
+    $before = SnapCount
+    Invoke-Save
+    Check "live session still writes a snapshot (no false skip)" ((SnapCount) -eq ($before + 1))
+
+    # 4. KNOWN GAP (characterization, not a fix): a PARTIAL capture is still written.
+    #    'partial' reports alpha (1 window) + beta (0 windows, mid-startup). The 0-session
+    #    guard sees >=1 session so it does NOT skip -> a degraded snapshot is persisted.
+    #    Pin both that it writes AND that the degradation (beta with no windows) is what
+    #    landed, so a future partial-capture fix has a concrete red/green target.
+    Reset-GoodLast
+    Set-FakePsmux 'partial'
+    $before = SnapCount
+    Invoke-Save
+    Check "[known-gap] partial capture is still written (follow-up target)" ((SnapCount) -eq ($before + 1))
+    $snap = Newest-Snap
+    $obj  = if ($snap) { Get-Content $snap.FullName -Raw | ConvertFrom-Json } else { $null }
+    $alpha = if ($obj) { $obj.sessions | Where-Object { $_.name -eq 'alpha' } } else { $null }
+    $beta  = if ($obj) { $obj.sessions | Where-Object { $_.name -eq 'beta' } }  else { $null }
+    Check "[known-gap] the persisted snapshot is degraded (alpha has windows, beta has none)" `
+        ($alpha -and $beta -and (@($alpha.windows).Count -ge 1) -and (-not $beta.windows))
+}
+finally {
+    Remove-Item $sandbox -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "`n=== Results: $pass passed, $fail failed ===" -ForegroundColor $(if ($fail) { 'Red' } else { 'Green' })
+exit $(if ($fail) { 1 } else { 0 })


### PR DESCRIPTION
Part of #26.

`save.ps1` could persist a 0-session snapshot and repoint `~/.psmux/resurrect/last` to it. When no server is running, `list-sessions` returns empty (psmux exits 0 with no output), so the capture is empty — but the snapshot was still written and `last` repointed, and the 20-slot rotation then evicted the good snapshots, silently destroying the ability to resurrect.

This adds a guard after the session-capture loop: if 0 sessions were captured, skip the write entirely and leave `last` untouched. A 0-session capture means the server is down (psmux/tmux destroys the server when its last session is gone), so an empty snapshot is never worth persisting — and persisting it is actively harmful. The guard sits before the dedup/write/rotation.

It protects every caller of `save.ps1` (the continuum auto-save loop, the `client-detached` save hook, and the manual `Prefix+Ctrl-s` binding), so the invariant "never persist a meaningless snapshot" lives with the writer rather than being re-implemented per caller.

**Known limitation (follow-up, not fixed here):** a *partial* capture — a server mid-startup reporting some-but-not-all sessions — is not covered; that snapshot has ≥1 session so it passes this guard and is written. Closing that needs an expected-session-count signal the script doesn't have today.

**Tests:** `tests/test_resurrect_guard.ps1` — hermetic (fake-psmux shim resolved via `PATHEXT` + redirected `$env:USERPROFILE`; needs no server and no real psmux binary, unlike the existing `test_resurrect*.ps1` which wipe the real `~/.psmux/resurrect`). Asserts: an empty capture writes nothing and leaves `last` byte-identical (both with a prior good `last` and on a virgin dir, so the guard is exercised independently of the dedup); a live session still writes (no false skip); and a characterization test pinning the known partial-capture gap.

**Validation:** there is no CI in this repo and the live E2E harness is destructive against the real resurrect dir, so this was validated via the hermetic sandbox test above + code reasoning — not a CI run.
