### PR TITLE
fix(continuum): break auto-save loop on empty psmux output (follow-up to #24)

### DIFF
--- a/psmux-continuum/psmux-continuum.ps1
+++ b/psmux-continuum/psmux-continuum.ps1
@@ -42,6 +42,22 @@ param(
 
 $ErrorActionPreference = 'Continue'
 
+# --- Single-instance guard -------------------------------------------------
+# The client-attached hook in plugin.conf fires on EVERY attach, so without a
+# guard a new auto-save loop would spawn on each attach and never exit, leaving
+# dozens of pwsh processes running (issue #24). A named mutex keeps a single
+# auto-save loop per user session; later instances exit immediately. If the
+# previous owner was killed the mutex is abandoned and we reclaim it.
+$mutex = New-Object System.Threading.Mutex($false, 'Local\psmux-continuum-autosave')
+try {
+    $haveLock = $mutex.WaitOne(0)
+} catch [System.Threading.AbandonedMutexException] {
+    $haveLock = $true
+}
+if (-not $haveLock) {
+    exit 0
+}
+
 function Get-PsmuxBin {
     foreach ($n in @('psmux','pmux','tmux')) {
         $b = Get-Command $n -ErrorAction SilentlyContinue
@@ -65,19 +81,28 @@ if (-not (Test-Path $saveScript)) {
 
 $IntervalSeconds = $IntervalMinutes * 60
 
-while ($true) {
-    Start-Sleep -Seconds $IntervalSeconds
+try {
+    while ($true) {
+        Start-Sleep -Seconds $IntervalSeconds
 
-    # Check if psmux server is still running
-    $sessions = & $PSMUX ls 2>&1 | Out-String
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "psmux-continuum: Server not running, stopping auto-save." -ForegroundColor Yellow
-        break
+        # Check if psmux server is still running.
+        # NOTE: psmux returns exit 0 with EMPTY output when no server exists, so the
+        # exit-code check alone never fires -- the loop would run forever and (without the
+        # resurrect 0-session guard) drive empty-snapshot writes. Treat empty output as
+        # "no server" too. ($sessions is only used for this liveness check, never saved.)
+        $sessions = & $PSMUX ls 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0 -or -not $sessions.Trim()) {
+            Write-Host "psmux-continuum: No psmux server, stopping auto-save." -ForegroundColor Yellow
+            break
+        }
+
+        # Run the save
+        & pwsh -NoProfile -File $saveScript
+        Write-Host "psmux-continuum: Auto-saved at $(Get-Date -Format 'HH:mm:ss')" -ForegroundColor DarkGray
     }
-
-    # Run the save
-    & pwsh -NoProfile -File $saveScript
-    Write-Host "psmux-continuum: Auto-saved at $(Get-Date -Format 'HH:mm:ss')" -ForegroundColor DarkGray
+} finally {
+    try { $mutex.ReleaseMutex() } catch {}
+    $mutex.Dispose()
 }
 '@
 

--- a/psmux-continuum/scripts/auto_save.ps1
+++ b/psmux-continuum/scripts/auto_save.ps1
@@ -49,10 +49,14 @@ try {
     while ($true) {
         Start-Sleep -Seconds $IntervalSeconds
 
-        # Check if psmux server is still running
+        # Check if psmux server is still running.
+        # NOTE: psmux returns exit 0 with EMPTY output when no server exists, so the
+        # exit-code check alone never fires -- the loop would run forever and (without the
+        # resurrect 0-session guard) drive empty-snapshot writes. Treat empty output as
+        # "no server" too. ($sessions is only used for this liveness check, never saved.)
         $sessions = & $PSMUX ls 2>&1 | Out-String
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "psmux-continuum: Server not running, stopping auto-save." -ForegroundColor Yellow
+        if ($LASTEXITCODE -ne 0 -or -not $sessions.Trim()) {
+            Write-Host "psmux-continuum: No psmux server, stopping auto-save." -ForegroundColor Yellow
             break
         }
 

--- a/tests/test_continuum_guard.ps1
+++ b/tests/test_continuum_guard.ps1
@@ -1,0 +1,76 @@
+#!/usr/bin/env pwsh
+# =============================================================================
+# psmux-continuum: auto-save break-on-empty + here-string drift guard (PR2)
+# =============================================================================
+# Static, hermetic asserts (no server, no binary): the auto-save loop must treat
+# empty `psmux ls` output as "no server", and the committed scripts/auto_save.ps1
+# must stay byte-identical to the here-string in psmux-continuum.ps1 that
+# regenerates it on every plugin load (Set-Content -Force) -- otherwise a reload
+# silently reverts the single-instance mutex from #24 (and this break-on-empty).
+# Run:  pwsh -File tests/test_continuum_guard.ps1
+# =============================================================================
+$ErrorActionPreference = 'Continue'
+
+$pass = 0; $fail = 0
+function Check($name, $cond, $detail = '') {
+    if ($cond) { Write-Host "  PASS: $name" -ForegroundColor Green; $script:pass++ }
+    else       { Write-Host "  FAIL: $name$(if($detail){' >> ' + $detail})" -ForegroundColor Red; $script:fail++ }
+}
+
+$PLUGIN_ROOT = Split-Path $PSScriptRoot -Parent
+$AUTO_SAVE   = Join-Path $PLUGIN_ROOT 'psmux-continuum\scripts\auto_save.ps1'
+$CONTINUUM   = Join-Path $PLUGIN_ROOT 'psmux-continuum\psmux-continuum.ps1'
+
+Write-Host "`n=== psmux-continuum break-on-empty / drift guard ===" -ForegroundColor Magenta
+
+$autoRaw = Get-Content $AUTO_SAVE -Raw
+$contRaw = Get-Content $CONTINUUM -Raw
+
+# break-on-empty present in BOTH copies (committed file AND the here-string generator)
+Check "committed auto_save.ps1 breaks on empty output"        ($autoRaw.Contains('-not $sessions.Trim()'))
+Check "psmux-continuum.ps1 here-string breaks on empty output" ($contRaw.Contains('-not $sessions.Trim()'))
+
+# both retain the #24 single-instance mutex (so neither path drops it)
+Check "both copies retain the #24 single-instance mutex" `
+    ($autoRaw.Contains('psmux-continuum-autosave') -and $contRaw.Contains('psmux-continuum-autosave'))
+
+# the here-string regenerates byte-identical to the committed file (drift guard).
+# NB: compares the embedded literal rather than executing psmux-continuum.ps1 (which
+# has side effects: Start-Job, psmux calls). A future rename of $autoSaveScript would
+# make the regex miss -> empty $heredoc -> this fails LOUDLY, which is the safe outcome.
+$m = [regex]::Match($contRaw, "(?s)\`$autoSaveScript = @'\r?\n(.*?)\r?\n'@")
+$heredoc   = ($m.Groups[1].Value      -replace "`r`n","`n").TrimEnd("`n")
+$committed = ((Get-Content $AUTO_SAVE -Raw) -replace "`r`n","`n").TrimEnd("`n")
+Check "here-string was found in psmux-continuum.ps1" ($m.Success)
+Check "here-string regenerates byte-identical to committed auto_save.ps1" ($heredoc -ceq $committed)
+
+# --- Behavioral proof of the break DECISION ---------------------------------
+# The full loop can't be run in a unit test (it sleeps IntervalMinutes*60 then holds a
+# process-wide named mutex), so prove the decision the fix encodes directly. This mirrors
+# the exact condition in auto_save.ps1; the static asserts above prove that condition is
+# the one actually shipped in both copies.
+$break = { param([int]$code, [string]$out) ($code -ne 0) -or (-not $out.Trim()) }
+Check "decision: server DOWN (exit 0, empty) -> break  [the bug the fix closes]" (& $break 0 '')
+Check "decision: server DOWN (exit 0, whitespace) -> break"                       (& $break 0 "  `n ")
+Check "decision: server UP (exit 0, real sessions) -> keep looping"        (-not (& $break 0 "agents: 1 windows (created ...)"))
+Check "decision: hard error (exit 1) -> break"                                    (& $break 1 'error: connect failed')
+
+# --- Premise proof (the reason the OLD exit-code-only check failed) ----------
+# The whole bug rests on: psmux returns EXIT 0 with EMPTY output when no server exists.
+# Prove it with the REAL binary against a THROWAWAY socket -- this does NOT touch the
+# user's default server. Skips cleanly if no psmux is installed (keeps the suite runnable
+# on a binary-less/CI box).
+$psmuxBin = $null
+foreach ($n in 'psmux','pmux','tmux') { $c = Get-Command $n -ErrorAction SilentlyContinue; if ($c) { $psmuxBin = $c.Source; break } }
+if ($psmuxBin) {
+    $sock = 'psmux-guardtest-' + ([guid]::NewGuid().ToString('N').Substring(0,8))
+    $premiseOut = & $psmuxBin -L $sock ls 2>&1 | Out-String
+    $premiseCode = $LASTEXITCODE
+    Check "PREMISE: real psmux '-L <no server> ls' exits 0 (not non-zero)" ($premiseCode -eq 0) "exit=$premiseCode"
+    Check "PREMISE: real psmux '-L <no server> ls' emits empty output"     (-not $premiseOut.Trim()) "out=[$($premiseOut.Trim())]"
+} else {
+    Write-Host "  SKIP: no psmux binary on PATH -> premise check skipped" -ForegroundColor DarkGray
+}
+
+Write-Host "`n=== Results: $pass passed, $fail failed ===" -ForegroundColor $(if ($fail) { 'Red' } else { 'Green' })
+exit $(if ($fail) { 1 } else { 0 })


### PR DESCRIPTION
Part of #26. Follow-up to #24.

#24 made the auto-save loop single-instance (one per session). But the loop still decides "server gone" only from `$LASTEXITCODE -ne 0`, and `psmux ls` returns exit 0 with empty output when no server is running — so the surviving loop never exits. While the server is down it keeps invoking `save.ps1` every interval, which (before the resurrect-side 0-session guard) wrote empty snapshots that evicted good ones.

This treats empty output as "no server" too: `if ($LASTEXITCODE -ne 0 -or -not $sessions.Trim())`. (Same emptiness signal `save.ps1`'s own capture-retry loop already trusts.) `$sessions` is only used for the liveness check, never saved.

**Also fixes a latent #24 regression.** `auto_save.ps1` is generated on every plugin load by a here-string in `psmux-continuum.ps1` (`Set-Content ... -Force`). That here-string was never updated for #24 — it still lacked the single-instance mutex — so a plugin reload would regenerate `auto_save.ps1` *without* #24's mutex, silently reverting it. This PR re-syncs the here-string to match the committed `auto_save.ps1` (mutex + try/finally + this break-on-empty change), so the generated file is byte-identical to the committed one. A test asserts that byte-for-byte equality to prevent future drift.

I did not refactor away the generate-on-load duplication (committed file vs here-string) — that's a larger change; happy to file it separately if you'd like a single source of truth.

**Tests:** `tests/test_continuum_guard.ps1` — break-on-empty present in both the committed `auto_save.ps1` and the here-string; the here-string regenerates byte-identical to the committed file; both retain the #24 mutex; the break **decision** is unit-tested (incl. the bug case: exit 0 + empty → break); and a **premise** test uses the real psmux binary on a throwaway socket to confirm `psmux -L <no server> ls` returns exit 0 + empty. The running loop itself isn't executed end-to-end (it sleeps then holds a process-wide mutex, so it can't be isolated in a unit test) — the premise + decision + static-presence asserts cover that gap.

Pairs with the psmux-resurrect PR in #26: that 0-session guard is the keystone data-loss fix; this PR stops the loop that drives it.
