### PR TITLE
docs(pain-control): remove incorrect case-insensitivity note

### DIFF
--- a/psmux-pain-control/psmux-pain-control.ps1
+++ b/psmux-pain-control/psmux-pain-control.ps1
@@ -38,8 +38,6 @@ if ($resizeOpt -match '^\d+$') { $resizeStep = [int]$resizeOpt }
 
 # =============================================================================
 # PANE RESIZING (Alt + vim keys)
-# NOTE: psmux treats key bindings case-insensitively (H == h), so we use
-# Alt+h/j/k/l instead of Shift (H/J/K/L) for resize to avoid conflicts.
 # =============================================================================
 & $PSMUX bind-key -r M-h resize-pane -L $resizeStep 2>&1 | Out-Null
 & $PSMUX bind-key -r M-j resize-pane -D $resizeStep 2>&1 | Out-Null


### PR DESCRIPTION
The `NOTE` claims psmux treats key bindings case-insensitively (`H == h`), but psmux binding lookup is case-sensitive: in psmux core (psmux/psmux), `normalize_key_for_binding` in `src/config.rs` strips Shift while preserving character case, so `h` and `H` resolve to distinct bindings.

The note uses that false premise to justify the Alt-based resize keys; the section header (`# PANE RESIZING (Alt + vim keys)`) already documents the Alt keys, so removing the note loses nothing.